### PR TITLE
Fix image source of killer perks

### DIFF
--- a/src/components/PerkOverview.vue
+++ b/src/components/PerkOverview.vue
@@ -2,7 +2,7 @@
     <div class="perk-overview" :class="classes">
         <h2 class="perk-overview__toggle" @click="toggleCollapsed">{{type}} Perk Configuration</h2>
         <div v-if="isCollapsed" class="perk-overview__grid">
-            <PerkSwitch :key="perk.index" v-for="perk in perks" :perk="perk" />
+            <PerkSwitch :key="perk.index" v-for="perk in perks" :perk="perk" :type="type" />
         </div>
     </div>
 </template>

--- a/src/components/PerkSwitch.vue
+++ b/src/components/PerkSwitch.vue
@@ -17,14 +17,23 @@ export default {
       default () {
         return []
       }
+    },
+    type: {
+      type: String,
+      default: '',
+      required: true
     }
   },
 
   computed: {
+    imageFileName () {
+      return this.type === 'Survivor' ? 'perkslotsSurvSmall.png' : 'perkslotsKillSmall.png'
+    },
+
     cssProps () {
       let idx = this.perk.index
       return {
-        '--slotBg': `url('/img/perkslotsSurvSmall.png') 0 ${idx === 0 ? 0 : (128 * idx * -1) + 'px'}`
+        '--slotBg': `url('/img/${this.imageFileName}') 0 ${idx === 0 ? 0 : (128 * idx * -1) + 'px'}`
       }
     }
   }


### PR DESCRIPTION
The images of the killer perks were loaded incorrectly: Instead of the killer perk images, the survivor ones were used. This PR fixes that issue using the type to distinguish the perks correctly in terms of image source.